### PR TITLE
Inserted an article between two words where needed (i.e a).

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_example/README.md
+++ b/farmdata2_modules/fd2_tabs/fd2_example/README.md
@@ -75,7 +75,7 @@ To add a new sub-tab to the `xyz` module:
 
 ### JavaScript and CSS Libraries ###
 
-JavaScript and CSS libraries can be included in module by adding them to the module configuration files (i.e. `.info` and `.module`).  
+JavaScript and CSS libraries can be included in a module by adding them to the module configuration files (i.e. `.info` and `.module`).  
 
 #### Local Libraries ####
 


### PR DESCRIPTION
__Pull Request Description__

Fixes Issue #30 
This feature branches fixes a typo inside of the README.md file that can be located in fd2_example folder which is inside the fd2_tabs folder which it inside the farmdata2_modules folder. The change simply adds an "a" between the words "in" and "branch" underneath the "JavaScript and CSS Libraries" section of the file. 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
